### PR TITLE
Support for resource sets with no memory

### DIFF
--- a/mesos/cli/cmds/ps.py
+++ b/mesos/cli/cmds/ps.py
@@ -43,7 +43,9 @@ parser.task_argument(optional=True)
 
 def get_memory(x):
     max_mem = x["resources"]["mem"] * 1024 * 1024 * 1.0
-    return "{0:.2f}".format((x.rss / max_mem) * 100)
+    if max_mem > 0
+        return "{0:.2f}".format((x.rss / max_mem) * 100)
+    return "0"
 
 
 @cli.init(parser)


### PR DESCRIPTION
Some tasks do not have memory assigned to them, this change allows support for this in the CLI. Those tasks cause the following exception...

```
Traceback (most recent call last):
  File "/usr/local/bin/mesos-ps", line 11, in <module>
    sys.exit(main())
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/mesos/cli/cli.py", line 61, in wrapper
    return fn(*args, **kwargs)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/mesos/cli/cmds/ps.py", line 82, in main
    tb.add_row([fn(task) for fn in table_generator.values()])
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/mesos/cli/cmds/ps.py", line 44, in get_memory
    return "{0:.2f}".format((x.rss / max_mem) * 100)
ZeroDivisionError: float division by zero
```
