### PR TITLE
Fix syntax error in mesos ps

### DIFF
--- a/mesos/cli/cmds/ps.py
+++ b/mesos/cli/cmds/ps.py
@@ -43,7 +43,7 @@ parser.task_argument(optional=True)
 
 def get_memory(x):
     max_mem = x["resources"]["mem"] * 1024 * 1024 * 1.0
-    if max_mem > 0
+    if max_mem > 0:
         return "{0:.2f}".format((x.rss / max_mem) * 100)
     return "0"
 


### PR DESCRIPTION
A statement in ps was missing a colon. The test which previously
errored out now passes.