### PR TITLE
Enable additional ssh arguments

### DIFF
--- a/mesos/cli/cmds/ssh.py
+++ b/mesos/cli/cmds/ssh.py
@@ -33,6 +33,9 @@ parser.add_argument(
     help="""Name of the task."""
 ).completer = completion_helpers.task
 
+parser.add_argument(
+    '-s', "--ssh_args", type=str,
+    help="""provide any additional ssh arguments e.g.: -s "-l login_name -p port" """)
 
 @cli.init(parser)
 def main(args):
@@ -45,12 +48,17 @@ def main(args):
 
     task = MASTER.task(args.task)
 
-    cmd = [
-        "ssh",
+    cmd = ["ssh"]
+
+    if args.ssh_args is not None:
+        cmd += args.ssh_args.split()
+
+    cmd += [
         "-t",
         task.slave["hostname"],
         "cd {0} && bash".format(task.directory)
     ]
+
     if task.directory == "":
         print(term.red + "warning: the task no longer exists on the " +
               "target slave. Will not enter sandbox" + term.white + "\n\n")

--- a/mesos/cli/cmds/ssh.py
+++ b/mesos/cli/cmds/ssh.py
@@ -35,7 +35,7 @@ parser.add_argument(
 
 parser.add_argument(
     '-s', "--ssh_args", type=str,
-    help="""provide any additional ssh arguments e.g.: -s "-l login_name -p port" """)
+    help="""provide any additional ssh arguments (for example: -s "-l login_name -p port")""")
 
 @cli.init(parser)
 def main(args):

--- a/tests/integration/test_ssh.py
+++ b/tests/integration/test_ssh.py
@@ -53,6 +53,27 @@ class TestSsh(utils.MockState):
 
     @utils.patch_args([
         "mesos-ssh",
+        "-s",
+        "-l a-login-name -p a-port",
+        "app-215.3e6a099c-fcba-11e3-8b67-b6f6cc110ef2"
+    ])
+    def test_sandbox_with_ssh_args(self):
+        with mock.patch("os.execvp") as m:
+            mesos.cli.cmds.ssh.main()
+
+            m.assert_called_with("ssh", [
+                'ssh',
+                '-l',
+                'a-login-name',
+                '-p',
+                'a-port',
+                '-t',
+                '10.141.141.10',
+                'cd {0} && bash'.format(DIR)
+            ])
+
+    @utils.patch_args([
+        "mesos-ssh",
         "app-215.2e6508c3-fafd-11e3-a955-b6f6cc110ef2"
     ])
     def test_missing(self):


### PR DESCRIPTION
Added ability to provide any additional ssh arguments. 
This is to fix - https://github.com/mesosphere/mesos-cli/issues/54