### PR TITLE
Enable additional ssh arguments

### DIFF
--- a/mesos/cli/cmds/ssh.py
+++ b/mesos/cli/cmds/ssh.py
@@ -33,6 +33,7 @@ parser.add_argument(
     help="""Name of the task."""
 ).completer = completion_helpers.task
 
+parser.enable_command_arguments("Options (if any) to be passed through to the ssh command.")
 
 @cli.init(parser)
 def main(args):
@@ -45,12 +46,17 @@ def main(args):
 
     task = MASTER.task(args.task)
 
-    cmd = [
-        "ssh",
+    cmd = ["ssh"]
+
+    if args.command_arguments:
+        cmd += args.command_arguments
+
+    cmd += [
         "-t",
         task.slave["hostname"],
         "cd {0} && bash".format(task.directory)
     ]
+
     if task.directory == "":
         print(term.red + "warning: the task no longer exists on the " +
               "target slave. Will not enter sandbox" + term.white + "\n\n")

--- a/mesos/cli/cmds/ssh.py
+++ b/mesos/cli/cmds/ssh.py
@@ -33,7 +33,7 @@ parser.add_argument(
     help="""Name of the task."""
 ).completer = completion_helpers.task
 
-parser.enable_command_arguments("Options (if any) to be passed through to the ssh command.")
+parser.enable_command_arguments("Options (if any) to be passed to the ssh command.")
 
 @cli.init(parser)
 def main(args):

--- a/mesos/cli/cmds/ssh.py
+++ b/mesos/cli/cmds/ssh.py
@@ -33,7 +33,7 @@ parser.add_argument(
     help="""Name of the task."""
 ).completer = completion_helpers.task
 
-parser.enable_command_arguments("Options (if any) to be passed to the ssh command.")
+parser.command_arguments("Options (if any) to pass to the ssh command. Should be after the task (for example: mesos ssh task -l login_name -p port).")
 
 @cli.init(parser)
 def main(args):

--- a/mesos/cli/parser.py
+++ b/mesos/cli/parser.py
@@ -52,7 +52,7 @@ class ArgumentParser(argparse.ArgumentParser):
             help="""Path to view."""
         ).completer = completion_helpers.file
 
-    def enable_command_arguments(self, help_msg="(Optional) Any options to pass through to the system command."):
+    def command_arguments(self, help_msg="(Optional) Options to pass to the system command."):
         self.add_argument(
             'command_arguments', type=str, nargs=argparse.REMAINDER, default=None,
             help=help_msg, metavar="..."

--- a/mesos/cli/parser.py
+++ b/mesos/cli/parser.py
@@ -51,3 +51,9 @@ class ArgumentParser(argparse.ArgumentParser):
             'path', type=str, nargs="?", default="",
             help="""Path to view."""
         ).completer = completion_helpers.file
+
+    def enable_command_arguments(self, help_msg="(Optional) Any options to pass through to the system command."):
+        self.add_argument(
+            'command_arguments', type=str, nargs=argparse.REMAINDER, default=None,
+            help=help_msg, metavar="..."
+        )

--- a/tests/integration/test_ssh.py
+++ b/tests/integration/test_ssh.py
@@ -53,6 +53,29 @@ class TestSsh(utils.MockState):
 
     @utils.patch_args([
         "mesos-ssh",
+        "app-215.3e6a099c-fcba-11e3-8b67-b6f6cc110ef2",
+        "-l",
+        "a-login-name",
+        "-p",
+        "a-port"
+    ])
+    def test_sandbox_with_ssh_args(self):
+        with mock.patch("os.execvp") as m:
+            mesos.cli.cmds.ssh.main()
+
+            m.assert_called_with("ssh", [
+                'ssh',
+                '-l',
+                'a-login-name',
+                '-p',
+                'a-port',
+                '-t',
+                '10.141.141.10',
+                'cd {0} && bash'.format(DIR)
+            ])
+
+    @utils.patch_args([
+        "mesos-ssh",
         "app-215.2e6508c3-fafd-11e3-a955-b6f6cc110ef2"
     ])
     def test_missing(self):


### PR DESCRIPTION
* Added the ability for a command to enable pass through arguments (i.e., allow unknown arguments to pass through to the system command.)
 * In code: the call to enable arguments should be after the command's own optional/positional arguments are set up (see note below.)
 * When running: the additional arguments should be given at the end. For example: ```mesos ssh some-task -l login_name```

* Enabled this for mesos-ssh. 
* This is to fix - #54

Note:
It appears that mixing unknown arguments with known arguments is causing problems (esp. argparse does not like being given unknown optional arguments first.) For example picking up "-l login_name" from:
>
mesos ssh -l login_name task 

does not work as easily as picking it up from: 
>
mesos ssh task -l login_name

Also, the first positional parameter will be taken up as the one that the command needs. So, in the first form above login_name will be taken as task because mesos-ssh is looking for a positional parameter.

I suppose hacky workarounds can be done but makes the code hard to maintain, and the solution less generic.