### PR TITLE
Fixing file descriptor leak in ZK client context manager

### DIFF
--- a/mesos/cli/zookeeper.py
+++ b/mesos/cli/zookeeper.py
@@ -44,3 +44,4 @@ def client(*args, **kwargs):
         yield zk
     finally:
         zk.stop()
+        zk.close()


### PR DESCRIPTION
Per http://kazoo.readthedocs.org/en/latest/api/client.html for ``kazoo.client.KazooClient`` objects:

>  close()
> 
>  Free any resources held by the client. This method should be called on a stopped client before it is discarded. Not doing so may result in filehandles being leaked.

In mesos.cli client code there is no ``close()``, just ``stop()``, which does lead to file description leak for long running applications using this library.