### PR TITLE
Prevent failing tests from auto dropping into pdb prompt

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,6 @@ verbosity=1
 detailed-errors=1
 with-coverage=0
 with-profile=0
-pdb=0
-pdb-failures=0
 tests=tests
 
 [isort]


### PR DESCRIPTION
It looks like setup.cfg was meant to turn pdb off in nosetests, but it's actually turning it on, which is making failing tests drop into a pdb prompt.

Reference: http://nose.readthedocs.org/en/latest/plugins/debug.html
"--pdb" doesn't take a value, so "--pdb=0" actually turns pdb on, not off

