### PR TITLE
Enable explicit ssh arguments and custom ssh program

### DIFF
--- a/mesos/cli/cmds/ssh.py
+++ b/mesos/cli/cmds/ssh.py
@@ -33,6 +33,10 @@ parser.add_argument(
     help="""Name of the task."""
 ).completer = completion_helpers.task
 
+parser.add_argument(
+    '-s', '--ssh', type=str,
+    help="""ssh command with arguments (for example: -s "ssh -l login_name -p port")."""
+)
 
 @cli.init(parser)
 def main(args):
@@ -45,15 +49,20 @@ def main(args):
 
     task = MASTER.task(args.task)
 
-    cmd = [
-        "ssh",
+    if args.ssh is not None:
+        cmd = args.ssh.split()
+    else:
+        cmd = ["ssh"]
+
+    cmd += [
         "-t",
         task.slave["hostname"],
         "cd {0} && bash".format(task.directory)
     ]
+
     if task.directory == "":
         print(term.red + "warning: the task no longer exists on the " +
               "target slave. Will not enter sandbox" + term.white + "\n\n")
         cmd = cmd[:-1]
 
-    log.fn(os.execvp, "ssh", cmd)
+    log.fn(os.execvp, cmd[0], cmd)

--- a/tests/integration/test_ssh.py
+++ b/tests/integration/test_ssh.py
@@ -53,6 +53,46 @@ class TestSsh(utils.MockState):
 
     @utils.patch_args([
         "mesos-ssh",
+        "app-215.3e6a099c-fcba-11e3-8b67-b6f6cc110ef2",
+        "-s ssh -l a-login-name -p a-port"
+    ])
+    def test_sandbox_with_ssh_args(self):
+        with mock.patch("os.execvp") as m:
+            mesos.cli.cmds.ssh.main()
+
+            m.assert_called_with("ssh", [
+                'ssh',
+                '-l',
+                'a-login-name',
+                '-p',
+                'a-port',
+                '-t',
+                '10.141.141.10',
+                'cd {0} && bash'.format(DIR)
+            ])
+
+    @utils.patch_args([
+        "mesos-ssh",
+        "app-215.3e6a099c-fcba-11e3-8b67-b6f6cc110ef2",
+        "-s /a-dir/custom-ssh -l a-login-name -p a-port"
+    ])
+    def test_sandbox_with_custom_ssh_and_args(self):
+        with mock.patch("os.execvp") as m:
+            mesos.cli.cmds.ssh.main()
+
+            m.assert_called_with("/a-dir/custom-ssh", [
+                '/a-dir/custom-ssh',
+                '-l',
+                'a-login-name',
+                '-p',
+                'a-port',
+                '-t',
+                '10.141.141.10',
+                'cd {0} && bash'.format(DIR)
+            ])
+
+    @utils.patch_args([
+        "mesos-ssh",
         "app-215.2e6508c3-fafd-11e3-a955-b6f6cc110ef2"
     ])
     def test_missing(self):


### PR DESCRIPTION
Added the ability to optionally provide ssh arguments as well as a different ssh program.
Examples:
- `mesos ssh -s "ssh -l login_name" taskname`
- `mesos ssh -s "/some/other/ssh -l login_name" taskname`
- `mesos ssh taskname` (as is)

This is to fix - #54. 
Some prior discussions are [here](https://github.com/mesosphere/mesos-cli/pull/55).
