### PR TITLE
Updates mesos-cli to understand JSON MasterInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ nosetests.xml
 
 # Translations
 *.mo
+
+.idea/
+.mesos.json
+


### PR DESCRIPTION
Jira: MESOS-3556

As of Mesos 0.24 we store data for MasterInfo in JSON
format instead of serialized protobuf: this fix addresses
the new format, while keeping it compatible with earlier versions
of Mesos.

Tested against a recently released 0.24.1 Mesos, running against
a local ZooKeeper.